### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     name: K6 test Build Runner
     runs-on: ubuntu-latest
     container:
-      image: golang:1.20-alpine
+      image: golang:1.22-alpine
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
/go/pkg/mod/go.opentelemetry.io/otel@v1.30.0/attribute/set.go:7:2: package cmp is not in GOROOT (/usr/local/go/src/cmp)

/go/pkg/mod/github.com/grafana/xk6-webcrypto@v0.4.0/webcrypto/elliptic_curve.go:4:2: package crypto/ecdh is not in GOROOT (/usr/local/go/src/crypto/ecdh)

package k6

imports go.k6.io/k6/cmd
imports golang.org/x/crypto/x509roots/fallback: build constraints exclude all Go files in /go/pkg/mod/golang.org/x/crypto/x509roots/fallback@v0.0.0-20240806160748-b2d3a6a4b4d3

/go/pkg/mod/google.golang.org/grpc@v1.67.1/experimental/stats/metricregistry.go:22:2: package maps is not in GOROOT (/usr/local/go/src/maps)

/go/pkg/mod/go.opentelemetry.io/otel@v1.30.0/attribute/set.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)

2024/10/14 05:05:45 [INFO] Cleaning up temporary folder: /tmp/buildenv_2024-10-14-0505.4108108744

so changed go version from 1.20 to 1.22